### PR TITLE
#034  Fix: Max width of Even Section text

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -62,7 +62,7 @@ module.exports = {
         53.25: "13.3125rem", // 213px
       },
       screens: {
-        xs: "22.5rem", // 360px
+        xs: "360px", // 360px
       },
       spacing: {
         0.25: "0.0625rem", // 1px


### PR DESCRIPTION
# PR
## PR Description
This PR change the screens(xs) in tailwind config from rem to px to fix the maximum width of even section text . 
## Task ID and Ticket Card Link
Task ID: #034

Ticket Card Link: [Here](https://www.notion.so/apeunit/Fix-max-width-of-the-text-in-the-Even-section-on-Desktop-Screen-2058807195f7405984daebaae53b16d2)

## Completed Tasks
- [ ] Changed xs in tailwind config to 360px

## Testing
npm run dev
localhost:3000