### PR TITLE
#033 Feat: Change The Space Between Even And Header Section On Desktop

### DIFF
--- a/components/layout/Header.jsx
+++ b/components/layout/Header.jsx
@@ -3,7 +3,7 @@ import Anchor from "@/components/ui/Anchor";
 
 export default function Header() {
   return (
-    <div className="font-variation grid grid-cols-1 sm:grid-cols-2 mb-13.25 sm:mb-44 xl:mb-64.5">
+    <div className="font-variation grid grid-cols-1 sm:grid-cols-2 mb-13.25 sm:mb-44 xl:mb-52">
       <div className="flex flex-wrap sm:col-start-2 sm:flex-nowrap">
         <div className="flex-1 sm:flex-initial">
           <div className="sm:border-l-0.5 border-black pt-5 pr-0.5 sm:pr-2.5 pb-4.25 sm:pl-2.5 sm:pt-10 sm:pb-0.5 xl:pl-5 xl:pr-10 xl:pb-0">


### PR DESCRIPTION
# PR
## PR Description
change the margin-bottom of the header section to 208px

## Task ID and Ticket Card Link
Task ID: #033

Ticket Card Link: [here](https://www.notion.so/apeunit/Decrease-the-margin-bottom-of-the-header-on-desktop-screen-0e8dbafa12d847a6be508bb8a9456c13)

## Completed Tasks
- [x] change the margin bottom t o208px

## Testing
- npm install
- npm run dev
- check the space between the even and the header section