### PR TITLE
# 035 Fix: Remove Unnecessary Padding in the First Column of the Footer

### DIFF
--- a/components/layout/Footer.jsx
+++ b/components/layout/Footer.jsx
@@ -5,7 +5,7 @@ export default function Footer() {
   return (
     <div className="grid mt-20 font-variation sm:grid-cols-2 sm:mt-25">
       <div className="grid grid-cols-2 sm:flex">
-        <div className="flex-1 xl:max-w-75 pt-0.5 sm:pt-0.75 xl:pt-0 pl-0 xl:pl-10.5 xl:pr-16 pr-0 sm:pr-2">
+        <div className="flex-1 xl:flex-initial pt-0.5 sm:pt-0.75 xl:pt-0 pl-0 pr-0 sm:pr-2">
           <div className="max-w-none sm:max-w-48.5 xl:w-full">
             <h5 className="font-variation-secondary block font-semibold sm:text-sm text-xs -tracking-tight leading-3.63 sm:leading-4.25 text-black">
               Even


### PR DESCRIPTION
# PR
## PR Description
Remove unnecessary padding in the first column of the footer on the desktop screen.
## Task ID and Ticket Card Link
Task ID: # 035
Ticket Card Link: [here](https://www.notion.so/apeunit/Fix-padding-in-the-footer-section-appears-to-be-large-d72ca8328e424c3b952baa9d88eb2483)
## Completed Tasks
- [x] remove the max-width of the first column
- [x] remove the padding of the first column
## Testing
- npm run install
- npm run dev
- check the desktop