### PR TITLE
#052 Rename Logo Custom Property To 60/23

### DIFF
--- a/components/sections/Even.jsx
+++ b/components/sections/Even.jsx
@@ -4,7 +4,7 @@ import { Span } from "@/components/ui/Typography";
 export default function Even() {
   return (
     <div>
-      <div className="relative w-full aspect-logo">
+      <div className="relative w-full aspect-60/23">
         <Image src="/svg/even.svg" fill alt="logo" priority />
       </div>
       <div className="max-w-62.5 xs:max-w-87.5 sm:max-w-113.05 md:max-w-127.18 lg:max-w-141.31 xl:max-w-219.31 mx-auto sm:mx-0 mt-10 relative pr-4 sm:pr-0">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
   theme: {
     extend: {
       aspectRatio: {
-        logo: "60/23",
+        "60/23": "60/23",
       },
       borderWidth: {
         0.5: "0.03125rem", 


### PR DESCRIPTION
# PR
## PR Description
rename logo custom property to 60/23 in the tailwind config

## Task ID and Ticket Card Link
Task ID: # 052

Ticket Card Link: [here](https://www.notion.so/apeunit/Custom-aspect-ratio-83c2eac01080481dad83df13a3de4b2d?pvs=4)

## Completed Tasks

- [x] change logo to 60/23
## demo link
[here](https://deploy-preview-83--evenmusic-apeunit.netlify.app/)
## Testing
- npm install
- npm run dev