### PR TITLE
#046 Fix: Remove Expanded classNames

### DIFF
--- a/components/layout/Footer.jsx
+++ b/components/layout/Footer.jsx
@@ -7,16 +7,16 @@ export default function Footer() {
   return (
     <div className="grid mt-20 sm:grid-cols-2 sm:mt-25">
       <div className="grid grid-cols-2 sm:flex 1.5lg:grid xl:flex 1.5xl:grid">
-        <div className="flex-1 xl:flex-initial pt-0.5 sm:pt-0.75 xl:pt-0 pl-0 pr-0 sm:pr-2">
+        <div className="flex-1 xl:flex-initial pt-0.5 sm:pt-0.75 xl:pt-0 px-0 sm:pr-2">
           <div className="max-w-none sm:max-w-48.5 md:max-w-54.56 lg:max-w-60.62 xl:max-w-72 xl:w-full">
             <h5
               className="block font-semibold sm:text-sm text-xs -tracking-0.1 text-primary text-opacity-95 leading-0.3"
               style={
                 scale > 1
                   ? {
-                    fontSize: `${0.875 * scale}rem`,
-                    letterSpacing: `${-0.025 * scale}rem`,
-                  }
+                      fontSize: `${0.875 * scale}rem`,
+                      letterSpacing: `${-0.025 * scale}rem`,
+                    }
                   : null
               }
             >
@@ -26,16 +26,16 @@ export default function Footer() {
             <Span>10999 Berlin Germany</Span>
           </div>
         </div>
-        <div className="flex-1 sm:flex-initial xl:flex-1 border-l-0.5 border-black pt-1 pl-5 sm:pt-0.75 xl:pt-0 sm:pl-2.5 xl:pl-5 pr-0 sm:pr-2.5 xl:pr-0">
+        <div className="flex-1 sm:flex-initial xl:flex-1 border-l-0.5 border-black pt-1 pl-5 sm:pt-0.75 xl:pt-0 sm:px-2.5 xl:pl-5 pr-0 xl:pr-0">
           <div className="max-w-33 sm:max-w-38.75 md:max-w-43.59 lg:max-w-48.43 xl:max-w-60">
             <h5
               className="block font-semibold sm:text-sm text-xs -tracking-0.1 text-primary text-opacity-95 leading-0.3"
               style={
                 scale > 1
                   ? {
-                    fontSize: `${0.875 * scale}rem`,
-                    letterSpacing: `${-0.025 * scale}rem`,
-                  }
+                      fontSize: `${0.875 * scale}rem`,
+                      letterSpacing: `${-0.025 * scale}rem`,
+                    }
                   : null
               }
             >
@@ -46,7 +46,7 @@ export default function Footer() {
         </div>
       </div>
       <div className="grid grid-cols-2 sm:flex 1.5lg:grid xl:flex">
-        <div className="flex-1 lg:flex-initial xl:pr-10 sm:border-l-0.5 border-black pt-5 pb-5 sm:pb-10 sm:pt-0.75 xl:pt-0 pr-1 sm:pr-2.5 pl-0 sm:pl-2.5 xl:pl-5">
+        <div className="flex-1 lg:flex-initial xl:pr-10 sm:border-l-0.5 border-black py-5 sm:pb-10 sm:pt-0.75 xl:pt-0 pr-1 sm:pr-2.5 pl-0 sm:pl-2.5 xl:pl-5">
           <div className="max-w-48.25 sm:max-w-xs md:max-w-56 lg:max-w-67.2 xl:max-w-xs lg:pr-1.5 xl:w-full">
             <Span>
               We are developers, designers, researchers and music enthusiast
@@ -63,9 +63,9 @@ export default function Footer() {
               style={
                 scale > 1
                   ? {
-                    fontSize: `${0.625 * scale}rem`,
-                    letterSpacing: `${-0.025 * scale}rem`,
-                  }
+                      fontSize: `${0.625 * scale}rem`,
+                      letterSpacing: `${-0.025 * scale}rem`,
+                    }
                   : null
               }
             >
@@ -76,9 +76,9 @@ export default function Footer() {
               style={
                 scale > 1
                   ? {
-                    fontSize: `${0.625 * scale}rem`,
-                    letterSpacing: `${-0.025 * scale}rem`,
-                  }
+                      fontSize: `${0.625 * scale}rem`,
+                      letterSpacing: `${-0.025 * scale}rem`,
+                    }
                   : null
               }
             >

--- a/components/layout/Header.jsx
+++ b/components/layout/Header.jsx
@@ -6,7 +6,7 @@ export default function Header() {
     <div className="grid grid-cols-1 sm:grid-cols-2 mb-13.25 sm:mb-44 xl:mb-52">
       <div className="flex flex-wrap sm:col-start-2 sm:flex-nowrap">
         <div className="flex-1 sm:flex-initial">
-          <div className="sm:border-l-0.5 border-black pt-5 pr-0.5 sm:pr-2.5 pb-4.25 sm:pl-2.5 sm:pt-10 sm:pb-0.5 xl:pl-5 xl:pr-10 xl:pb-0">
+          <div className="sm:border-l-0.5 border-black pt-5 pr-0.5 sm:px-2.5 pb-4.25 sm:pt-10 sm:pb-0.5 xl:pl-5 xl:pr-10 xl:pb-0">
             <div className="max-w-48.25 sm:max-w-xs md:max-w-56 lg:max-w-67.2 xl:max-w-xs pr-4.5 sm:pr-3">
               <Span>
                 Even wants to fundamentally change the way artists and their


### PR DESCRIPTION
# PR
## PR Description
Remove expanded padding class names.
## Task ID and Ticket Card Link
Task ID: # 046
Ticket Card Link: [here](https://www.notion.so/apeunit/Remove-expanded-classes-08d0a26587f247b0bccca505b52bf458?pvs=4)
## Completed Tasks
- [x] Remove expanded padding class names from Header components
- [x] Remove expanded padding class names from Footer components
## Testing
- npm run install
- npm run dev